### PR TITLE
feat: fallback to rtp resource if file not found and GitHub Login redirectUri

### DIFF
--- a/src/api/accounts/accounts-github/accounts-github.controller.ts
+++ b/src/api/accounts/accounts-github/accounts-github.controller.ts
@@ -3,6 +3,7 @@ import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 
 import { AccountsGithubService } from './accounts-github.service';
+import { AccountsLoginGithubDto } from './dto/accounts-login-github.dto';
 import { AccountsSignupGithubDto } from './dto/accounts-signup-github.dto';
 
 @ApiTags('Accounts Github')
@@ -12,8 +13,14 @@ export class AccountsGithubController {
 
   @Post('login')
   @ApiOperation({ summary: 'Login using GitHub' })
-  async login(@Req() req: Request): Promise<string> {
-    return await this.accountsGithubService.authorizeRequest(req);
+  async login(
+    @Req() req: Request,
+    @Body() githubLoginDto: AccountsLoginGithubDto,
+  ): Promise<string> {
+    return await this.accountsGithubService.authorizeRequest(
+      req,
+      githubLoginDto,
+    );
   }
 
   @Post('signup')

--- a/src/api/accounts/accounts-github/dto/accounts-login-github.dto.ts
+++ b/src/api/accounts/accounts-github/dto/accounts-login-github.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Matches } from 'class-validator';
+
+export class AccountsLoginGithubDto {
+  @ApiProperty({
+    default: '/oauth',
+  })
+  @Matches(/^\//, {
+    message: 'redirectUri should start with /',
+  })
+  redirectUri: string;
+}

--- a/src/api/accounts/accounts-github/dto/accounts-signup-github.dto.ts
+++ b/src/api/accounts/accounts-github/dto/accounts-signup-github.dto.ts
@@ -11,4 +11,12 @@ export class AccountsSignupGithubDto {
   })
   @Length(3, 15)
   username: string;
+
+  @ApiProperty({
+    default: '/oauth',
+  })
+  @Matches(/^\//, {
+    message: 'redirectUri should start with /',
+  })
+  redirectUri: string;
 }


### PR DESCRIPTION
# Pull Request Template

## Type of change

<!-- Please put an `x` in boxes that apply. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

Login and sign-up with GitHub requires `redirectUri` to be passed.

```json
{
  "redirectUri": "/oauth"
}
```

**Does this PR require a change to the documentation?** (check one)

- [x] Yes
- [ ] No

If yes, please update the documentation accordingly.

**Does this PR require a change to the environment variables configuration?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the changes that need to be updated in the configuration (put your example environment variables in the code block below).
```
```

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

<!-- If adding a **new feature**, please include a convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it). -->

### RTP resources fallback

Finished implementing [#91 issue (from the front-end)](https://github.com/w3itch-crafter/w3itch-frontend/issues/91).

If a game resource is not found in the game's directory, the server will then look for it in the `thirdparty/resources` directory with the same path.

### GitHub login/signup service

After the authentication is done, the backend redirect to `redirectUri` with the requested origin as the full URL, with multiple search parameters. 

```yaml
- code: HTTP status code
- success: true if login or signup was successful
- method: 'login' or 'signup' - only if the state found
- service: 'GitHub' here
```

For example, if the login is requested from `https://w3itch.io` with `"redirectUri": "/oauth"` and it's successful, you'll be redirected to:

```
https://w3itch.io/oauth?service=GitHub&method=login&success=true&code=200
```

If an error occurred, the code will be either 400 or 401 depending on:

```yaml
- failed to get the user information from GitHub (eg. user canceled the authentication, wrong clientId): 400
- login failed for any reason: 401
- signup failed for any reason: 400
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Desktop:**

<!-- Please complete the following information -->
<!-- Or paste your full system/browser information, e.g. the output of `uname -a`  -->
<!-- Darwin MacPro 20.6.0 Darwin Kernel Version 20.6.0 ... arm64  -->

- OS:
  - [ ] Windows [version]
  - [x] macOS [Darwin MacPro.local 21.3.0 Darwin Kernel Version 21.3.0]
  - [ ] Linux [version]
- Browser [e.g. chrome, safari]

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.